### PR TITLE
Drop BDE references as the code seems to be agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BDE Util Package
+# LINZ Util Perl Package
 
 Contains Modules to preform simple logging to file and load configuration
 information from a configuration file. 

--- a/lib/LINZ/Config.pm
+++ b/lib/LINZ/Config.pm
@@ -2,8 +2,6 @@
 #
 # $Id$
 #
-# linz_bde_loader -  LINZ BDE loader for PostgreSQL
-#
 # Copyright 2011 Crown copyright (c)
 # Land Information New Zealand and the New Zealand Government.
 # All rights reserved


### PR DESCRIPTION
As the acronym already confusing, I'm happy when it can be completely
removed :P